### PR TITLE
Encode `num_fixed_comms` to vka

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -389,7 +389,7 @@ impl<'a> SolidityGenerator<'a> {
                     "num_evals" => U256::from(self.meta.num_evals),
                     "num_neg_lagranges" => {
                         U256::from(self.meta.rotation_last.unsigned_abs() as usize)
-                    },
+                    }
                     "num_fixed_comms" => U256::from(self.meta.num_fixeds),
                     _ => dummy_val,
                 };

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -281,6 +281,7 @@ impl<'a> SolidityGenerator<'a> {
             ("pcs_computations_len_offset", U256::from(0)),
             ("rescaling_computations_len_offset", U256::from(0)),
             ("num_neg_lagranges", U256::from(0)),
+            ("num_fixed_comms", U256::from(0)),
         ];
 
         // Create a vector of tuples with the num_advices_user_challenges elements.
@@ -388,7 +389,8 @@ impl<'a> SolidityGenerator<'a> {
                     "num_evals" => U256::from(self.meta.num_evals),
                     "num_neg_lagranges" => {
                         U256::from(self.meta.rotation_last.unsigned_abs() as usize)
-                    }
+                    },
+                    "num_fixed_comms" => U256::from(self.meta.num_fixeds),
                     _ => dummy_val,
                 };
                 (name, value)


### PR DESCRIPTION
Encodes the number of fixed commitments into `constants` area of VKA for the external consumer of VKA.